### PR TITLE
Changed encryption mode from CCM to GCM

### DIFF
--- a/public/js/newpaste.js
+++ b/public/js/newpaste.js
@@ -168,7 +168,7 @@ $(document).ready(function() {
       setFormReadonly(true);
 
       // Encrypt the plain text using the password to a Base64 string
-      var enc_paste = sjcl.codec.base64.fromBits(sjcl.codec.utf8String.toBits(sjcl.encrypt($("#password").val(), original, {ks: 256})));
+      var enc_paste = sjcl.codec.base64.fromBits(sjcl.codec.utf8String.toBits(sjcl.encrypt($("#password").val(), original, {mode:"gcm", ks: 256})));
       $("#paste").val(enc_paste);
 
       // Check that the paste text is below the maximum character limit

--- a/public/js/viewpaste.js
+++ b/public/js/viewpaste.js
@@ -158,7 +158,7 @@ $(document).ready(function() {
     // Attempt to decrypt paste
     try {
       // Decrypt, escape, and set paste
-      var decrypted = sjcl.decrypt($("#password").val(), sjcl.codec.utf8String.fromBits(sjcl.codec.base64.toBits($("#paste").html())), {ks: 256});
+      var decrypted = sjcl.decrypt($("#password").val(), sjcl.codec.utf8String.fromBits(sjcl.codec.base64.toBits($("#paste").html())));
       cleaned_paste = decrypted.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
       $("#paste").html(cleaned_paste);
 


### PR DESCRIPTION
[#6](https://github.com/HackThisCode/CryptoPaste/issues/6)

This change is backwards compatible. Since the mode is stored with the cipher-text, the old pastes encrypted using CCM can still be decrypted.

Removed key size from decryption function. It is not needed since the key size is already stored with the cipher-text.